### PR TITLE
feat: add internet radio player and Zed to tools

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -46,6 +46,9 @@ import { initPong } from './games/pong.js';
 
 /** @typedef {'about' | 'skills' | 'experience' | 'projects' | 'contact'} Section */
 
+const RADIO_LABEL = 'SomaFM: Secret Agent';
+const RADIO_STREAM_URL = 'https://ice1.somafm.com/secretagent-128-mp3';
+
 /** @type {Readonly<Record<string, string>>} */
 const GAME_TITLES = Object.freeze({
 	space: 'SPACE INVADERS',
@@ -145,6 +148,12 @@ function amigaScreenHTML() {
 				<div class="status-bar">
 					<span>Chip: 2048K</span>
 					<span>Fast: 8192K</span>
+					<div class="radio-player">
+						<button class="radio-btn" type="button" data-action="toggle-radio" aria-label="Play radio">▶</button>
+						<span class="radio-label">${RADIO_LABEL}</span>
+						<span class="radio-eq" aria-hidden="true"><span></span><span></span><span></span></span>
+						<audio class="radio-audio" preload="none" src="${RADIO_STREAM_URL}"></audio>
+					</div>
 					<span class="status-right">v${version}</span>
 				</div>
 				<div class="scanlines"></div>
@@ -454,6 +463,45 @@ function playModemSound() {
 }
 
 // ---------------------------------------------------------------------------
+// Radio player — embedded internet radio (SomaFM)
+// ---------------------------------------------------------------------------
+
+function initRadioPlayer() {
+	const audio = /** @type {HTMLAudioElement | null} */ (document.querySelector('.radio-audio'));
+	const btn = /** @type {HTMLButtonElement | null} */ (document.querySelector('.radio-btn'));
+	const player = /** @type {HTMLElement | null} */ (document.querySelector('.radio-player'));
+	if (!audio || !btn || !player) return;
+
+	audio.addEventListener('error', () => {
+		btn.textContent = '▶';
+		btn.setAttribute('aria-label', 'Play radio');
+		player.classList.remove('playing');
+	});
+}
+
+function toggleRadio() {
+	const audio = /** @type {HTMLAudioElement | null} */ (document.querySelector('.radio-audio'));
+	const btn = /** @type {HTMLButtonElement | null} */ (document.querySelector('.radio-btn'));
+	const player = /** @type {HTMLElement | null} */ (document.querySelector('.radio-player'));
+	if (!audio || !btn || !player) return;
+
+	if (audio.paused) {
+		audio.play().then(() => {
+			btn.textContent = '⏸';
+			btn.setAttribute('aria-label', 'Pause radio');
+			player.classList.add('playing');
+		}).catch(() => {
+			// playback blocked or stream unavailable — stay stopped
+		});
+	} else {
+		audio.pause();
+		btn.textContent = '▶';
+		btn.setAttribute('aria-label', 'Play radio');
+		player.classList.remove('playing');
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Boot sequence
 // ---------------------------------------------------------------------------
 
@@ -463,6 +511,7 @@ function startBoot() {
 
 	app.innerHTML = amigaScreenHTML();
 	playModemSound();
+	initRadioPlayer();
 
 	const bootScreen = /** @type {HTMLDivElement} */ (document.getElementById('boot-screen'));
 	const cursor = /** @type {HTMLSpanElement} */ (bootScreen.querySelector('.cursor'));
@@ -566,6 +615,12 @@ app.addEventListener('click', (e) => {
 	// Download CV
 	if (target.closest('[data-action="download-cv"]')) {
 		downloadCv();
+		return;
+	}
+
+	// Toggle radio
+	if (target.closest('[data-action="toggle-radio"]')) {
+		toggleRadio();
 		return;
 	}
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,7 +21,7 @@ const skills = {
 	backend: ["Node.js", "Fastify", "FastAPI", "Flask", "Spring Boot"],
 	database: ["MongoDB", "Oracle", "MySQL"],
 	devops: ["Docker", "GitHub/Gitlab Actions", "Azure DevOps"],
-	tools: ["Git", "Neovim", "tmux", ""],
+	tools: ["Git", "Neovim", "tmux", "Zed"],
 	ai: ["LLM Integration", "Prompt Engineering", "AI Agents"]
 };
 

--- a/src/styles/page.css
+++ b/src/styles/page.css
@@ -276,6 +276,61 @@ html, body {
 
 .status-right { margin-left: auto; }
 
+.radio-player {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.radio-btn {
+	font-family: 'VT323', monospace;
+	font-size: 14px;
+	line-height: 1;
+	padding: 2px 6px;
+	background: transparent;
+	border: 1px solid #00ff41;
+	color: #00ff41;
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+.radio-btn:hover {
+	background: #00ff41;
+	color: #000;
+}
+
+.radio-label {
+	color: #00ff41;
+	white-space: nowrap;
+}
+
+.radio-eq {
+	display: flex;
+	align-items: flex-end;
+	gap: 2px;
+	height: 12px;
+}
+
+.radio-eq span {
+	width: 3px;
+	height: 4px;
+	background: #00ff41;
+	opacity: 0.3;
+}
+
+.radio-player.playing .radio-eq span {
+	opacity: 1;
+	animation: eq-bounce 0.9s ease-in-out infinite;
+}
+
+.radio-player.playing .radio-eq span:nth-child(2) { animation-delay: 0.2s; }
+.radio-player.playing .radio-eq span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes eq-bounce {
+	0%, 100% { height: 4px; }
+	50% { height: 12px; }
+}
+
 .scanlines {
 	position: absolute; top: 0; left: 0; right: 0; bottom: 0;
 	background: repeating-linear-gradient(0deg, rgba(0,0,0,0.15) 0px, rgba(0,0,0,0.15) 1px, transparent 1px, transparent 2px);
@@ -306,6 +361,7 @@ html, body {
 	.job-header { flex-direction: column; align-items: flex-start; }
 	.action-buttons { flex-direction: column; }
 	.amiga-btn { text-align: center; }
+	.radio-label { display: none; }
 }
 
 /* Desktop icons */


### PR DESCRIPTION
## Summary
- Added a retro mini radio player (SomaFM "Secret Agent" stream) to the status bar with play/pause toggle and an animated EQ indicator
- Filled the empty Tools slot with "Zed"

## Test plan
- [x] `npm run build` succeeds
- [x] Manually verified in dev server: radio play/pause toggles, EQ animates, Skills > Tools shows Zed

🤖 Generated with [Claude Code](https://claude.com/claude-code)