### PR TITLE
fix: dedupe index.html and refresh bio/meta copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
 	<!-- SEO Meta Tags -->
 	<meta name="description"
-		content="JavaScript-first Senior Engineer with 6+ years delivering production systems. Specializing in Node.js/React, CI/CD automation, and AI-integrated solutions." />
+		content="Senior JavaScript Engineer with 10 years shipping cloud-scale apps for millions of users — Node.js, React, Spring Boot, Kafka. Now leveling up in Python/FastAPI and AI agents." />
 	<meta name="keywords"
 		content="Alberto Barrago, Senior Software Engineer, JavaScript, Node.js, React, Angular, DevOps, CI/CD, AI Integration" />
 	<meta name="author" content="Alberto Barrago" />
@@ -19,14 +19,14 @@
 	<meta property="og:url" content="https://albz.it/" />
 	<meta property="og:title" content="Alberto Barrago - Senior Software Engineer" />
 	<meta property="og:description"
-		content="JavaScript-first Senior Engineer with 6+ years delivering production systems for millions of users." />
+		content="10 years turning coffee into production code for millions of users — Node.js, React, Spring Boot, Kafka, Python/FastAPI & AI agents on deck." />
 	<meta property="og:image" content="https://github.com/albertobarrago.png" />
 
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:title" content="Alberto Barrago - Senior Software Engineer" />
 	<meta name="twitter:description"
-		content="JavaScript-first Senior Engineer specializing in Node.js/React ecosystems and AI-integrated solutions." />
+		content="10 years turning coffee into production code for millions of users — Node.js, React, Spring Boot, Kafka, Python/FastAPI & AI agents on deck." />
 
 	<!-- Canonical URL -->
 	<link rel="canonical" href="https://albz.it/" />
@@ -37,7 +37,7 @@
 			"@context": "https://schema.org",
 			"@type": "Person",
 			"name": "Alberto Barrago",
-			"description": "Senior Software Engineer with 6+ years delivering production systems for millions of users.",
+			"description": "Senior Software Engineer with 10 years delivering cloud-scale production systems for millions of users.",
 			"image": "https://github.com/albertobarrago.png",
 			"url": "https://albz.it/",
 			"email": "albertobarrago@gmail.com",
@@ -54,63 +54,7 @@
 <body>
 	<div id="app"></div>
 	<script type="module" src="/src/js/app.js"></script>
-	<!doctype html>
-	<html lang="en">
 
-	<head>
-		<meta charset="utf-8" />
-		<title>Alberto Barrago - Senior Software Engineer</title>
-		<link rel="icon" href="/favicon.ico" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-
-		<!-- SEO Meta Tags -->
-		<meta name="description"
-			content="JavaScript-first Senior Engineer with 6+ years delivering production systems. Specializing in Node.js/React, CI/CD automation, and AI-integrated solutions." />
-		<meta name="keywords"
-			content="Alberto Barrago, Senior Software Engineer, JavaScript, Node.js, React, Angular, DevOps, CI/CD, AI Integration" />
-		<meta name="author" content="Alberto Barrago" />
-
-		<!-- Open Graph -->
-		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://albz.it/" />
-		<meta property="og:title" content="Alberto Barrago - Senior Software Engineer" />
-		<meta property="og:description"
-			content="JavaScript-first Senior Engineer with 6+ years delivering production systems for millions of users." />
-		<meta property="og:image" content="https://github.com/albertobarrago.png" />
-
-		<!-- Twitter -->
-		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:title" content="Alberto Barrago - Senior Software Engineer" />
-		<meta name="twitter:description"
-			content="JavaScript-first Senior Engineer specializing in Node.js/React ecosystems and AI-integrated solutions." />
-
-		<!-- Canonical URL -->
-		<link rel="canonical" href="https://albz.it/" />
-
-		<!-- Schema.org -->
-		<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": "Person",
-			"name": "Alberto Barrago",
-			"description": "Senior Software Engineer with 6+ years delivering production systems for millions of users.",
-			"image": "https://github.com/albertobarrago.png",
-			"url": "https://albz.it/",
-			"email": "albertobarrago@gmail.com",
-			"jobTitle": "Senior Software Engineer",
-			"knowsAbout": ["JavaScript", "Node.js", "React", "Angular", "DevOps", "CI/CD", "AI Integration"],
-			"sameAs": ["https://github.com/AlbertoBarrago"]
-		}
-		</script>
-
-		<link rel="stylesheet" href="/src/styles/main.css" />
-		<link rel="stylesheet" href="/src/styles/page.css" />
-	</head>
-
-	<body>
-		<div id="app"></div>
-		<script type="module" src="/src/js/app.js"></script>
-	</body>
 	<!-- Google tag (gtag.js) -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-NVRFS5LVBB"></script>
 	<script>
@@ -120,9 +64,6 @@
 
 		gtag('config', 'G-NVRFS5LVBB');
 	</script>
-
-	</html>
-
 </body>
 
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,14 +6,10 @@ const location = "Cagliari, Italy";
 const email = "albertobarrago@gmail.com";
 const cv_filename = "albertobarrago_cv.pdf";
 
-const profile = `JavaScript-first Senior Engineer with deep expertise in enterprise
-scalability and cloud architecture. A decade of delivering production
-systems for millions of users across frontend, backend, and DevOps—
-specializing in Node.js/React ecosystems, Spring Boot microservices,
-and CI/CD automation. Experienced in building component libraries and
-Kafka-based architectures. Currently developing Python/FastAPI skills
-and exploring AI-integrated solutions. Pragmatic builder who values code
-quality, collaborative shipping, and real measurable impact.
+const profile = `10 years turning coffee into production code for millions of users —
+Node.js, React, Spring Boot, Kafka, you name it. Currently grinding XP
+in Python/FastAPI and AI agents. Clean code, happy teammates, real
+impact: that's the cheat code.
 `;
 
 const skills = {


### PR DESCRIPTION
## Summary
- Removed a duplicated `<!doctype html>...</html>` document nested inside `<body>` of `index.html` — it was double-loading `src/js/app.js`, duplicating all meta tags, and producing invalid HTML (also present in the published build)
- Shortened/refreshed the About bio to a friendlier, retro-themed tone
- Updated meta/OG/Twitter/schema descriptions to match the new bio

## Test plan
- [x] `npm run build` succeeds
- [x] Built `index.html` has a single doctype, single `#app`, single gtag block