### PR TITLE
fix: normalize game timing

### DIFF
--- a/src/js/games/flappyBird.js
+++ b/src/js/games/flappyBird.js
@@ -16,12 +16,15 @@ export function initFlappyBird(canvas, onExit) {
 	const PIPE_SPEED = 2.8;
 	const PIPE_INTERVAL = 96;
 	const GROUND_H = 46;
+	const FRAME_MS = 1000 / 60;
 
 	let gameState = 'waiting';
 	let score = 0;
 	let highScore = parseInt(localStorage.getItem('flappyBirdHigh') || '0', 10);
 	let animFrameId = 0;
+	let lastFrameTime = 0;
 	let frame = 0;
+	let nextPipeFrame = PIPE_INTERVAL;
 	let birdX = 0;
 	let birdY = 0;
 	let birdVY = 0;
@@ -53,6 +56,7 @@ export function initFlappyBird(canvas, onExit) {
 		gameState = 'playing';
 		score = 0;
 		frame = 0;
+		nextPipeFrame = PIPE_INTERVAL;
 		pipes = [];
 		resetBird();
 		spawnPipe();
@@ -166,17 +170,21 @@ export function initFlappyBird(canvas, onExit) {
 	window.addEventListener('keydown', keyHandler);
 	canvas.addEventListener('pointerdown', pointerHandler);
 
-	function update() {
+	/** @param {number} deltaFrames */
+	function update(deltaFrames) {
 		if (gameState !== 'playing') return;
 
-		frame++;
-		birdVY += GRAVITY;
-		birdY += birdVY;
+		frame += deltaFrames;
+		birdVY += GRAVITY * deltaFrames;
+		birdY += birdVY * deltaFrames;
 
-		if (frame % PIPE_INTERVAL === 0) spawnPipe();
+		while (frame >= nextPipeFrame) {
+			spawnPipe();
+			nextPipeFrame += PIPE_INTERVAL;
+		}
 
 		for (const pipe of pipes) {
-			pipe.x -= PIPE_SPEED;
+			pipe.x -= PIPE_SPEED * deltaFrames;
 			if (!pipe.passed && pipe.x + PIPE_W < birdX) {
 				pipe.passed = true;
 				score++;
@@ -330,14 +338,19 @@ export function initFlappyBird(canvas, onExit) {
 		if (gameState === 'gameover') drawGameOver();
 	}
 
-	function gameLoop() {
-		update();
+	/** @param {number} timestamp */
+	function gameLoop(timestamp) {
+		if (lastFrameTime === 0) lastFrameTime = timestamp;
+		const deltaFrames = Math.min((timestamp - lastFrameTime) / FRAME_MS, 3);
+		lastFrameTime = timestamp;
+
+		update(deltaFrames);
 		draw();
 		animFrameId = requestAnimationFrame(gameLoop);
 	}
 
 	resetBird();
-	gameLoop();
+	animFrameId = requestAnimationFrame(gameLoop);
 
 	return function cleanup() {
 		cancelAnimationFrame(animFrameId);

--- a/src/js/games/pong.js
+++ b/src/js/games/pong.js
@@ -11,10 +11,12 @@ export function initPong(canvas, onExit) {
 	const PADDLE_W = 12, PADDLE_H = 80, BALL_SIZE = 10;
 	const PADDLE_SPEED = 5, BALL_BASE_SPEED = 4, AI_SPEED = 3.5;
 	const WIN_SCORE = 7;
+	const FRAME_MS = 1000 / 60;
 
 	let gameState = 'waiting';
 	let playerScore = 0, aiScore = 0;
 	let animFrameId = 0;
+	let lastFrameTime = 0;
 
 	function resize() { canvas.width = canvas.clientWidth; canvas.height = canvas.clientHeight; }
 	resize();
@@ -54,27 +56,29 @@ export function initPong(canvas, onExit) {
 	window.addEventListener('keydown', keyHandler);
 	window.addEventListener('keyup', keyUpHandler);
 
-	function update() {
+	/** @param {number} deltaFrames */
+	function update(deltaFrames) {
 		if (gameState !== 'playing') return;
 
 		// Player paddle
-		if (keys['ArrowUp'] && playerY > 0) playerY -= PADDLE_SPEED;
-		if (keys['ArrowDown'] && playerY < canvas.height - PADDLE_H) playerY += PADDLE_SPEED;
+		if (keys['ArrowUp'] && playerY > 0) playerY -= PADDLE_SPEED * deltaFrames;
+		if (keys['ArrowDown'] && playerY < canvas.height - PADDLE_H) playerY += PADDLE_SPEED * deltaFrames;
+		playerY = Math.max(0, Math.min(canvas.height - PADDLE_H, playerY));
 
 		// AI paddle
 		const aiCenter = aiY + PADDLE_H / 2;
 		if (ballDX > 0) {
-			if (aiCenter < ballY - 10) aiY += AI_SPEED;
-			else if (aiCenter > ballY + 10) aiY -= AI_SPEED;
+			if (aiCenter < ballY - 10) aiY += AI_SPEED * deltaFrames;
+			else if (aiCenter > ballY + 10) aiY -= AI_SPEED * deltaFrames;
 		} else {
-			if (aiCenter < canvas.height / 2 - 5) aiY += AI_SPEED * 0.5;
-			else if (aiCenter > canvas.height / 2 + 5) aiY -= AI_SPEED * 0.5;
+			if (aiCenter < canvas.height / 2 - 5) aiY += AI_SPEED * 0.5 * deltaFrames;
+			else if (aiCenter > canvas.height / 2 + 5) aiY -= AI_SPEED * 0.5 * deltaFrames;
 		}
 		aiY = Math.max(0, Math.min(canvas.height - PADDLE_H, aiY));
 
 		// Ball
-		ballX += ballDX;
-		ballY += ballDY;
+		ballX += ballDX * deltaFrames;
+		ballY += ballDY * deltaFrames;
 
 		// Top/bottom bounce
 		if (ballY <= 0) { ballY = 0; ballDY = Math.abs(ballDY); }
@@ -157,8 +161,17 @@ export function initPong(canvas, onExit) {
 		}
 	}
 
-	function gameLoop() { update(); draw(); animFrameId = requestAnimationFrame(gameLoop); }
-	gameLoop();
+	/** @param {number} timestamp */
+	function gameLoop(timestamp) {
+		if (lastFrameTime === 0) lastFrameTime = timestamp;
+		const deltaFrames = Math.min((timestamp - lastFrameTime) / FRAME_MS, 3);
+		lastFrameTime = timestamp;
+
+		update(deltaFrames);
+		draw();
+		animFrameId = requestAnimationFrame(gameLoop);
+	}
+	animFrameId = requestAnimationFrame(gameLoop);
 
 	return function cleanup() {
 		cancelAnimationFrame(animFrameId);

--- a/src/js/games/spaceInvaders.js
+++ b/src/js/games/spaceInvaders.js
@@ -13,11 +13,13 @@ export function initSpaceInvaders(canvas, onExit) {
 	const PLAYER_SPEED = 5, BULLET_SPEED = 7, ALIEN_BULLET_SPEED = 4;
 	const ALIEN_FIRE_CHANCE = 0.003;
 	const ROW_COLORS = ['#ff6b6b', '#ff6b6b', '#ffbd2e', '#ffbd2e', '#00ff41'];
+	const FRAME_MS = 1000 / 60;
 
 	let gameState = 'waiting';
 	let score = 0, lives = 3;
 	let highScore = parseInt(localStorage.getItem('spaceInvadersHigh') || '0', 10);
 	let animFrameId = 0;
+	let lastFrameTime = 0;
 
 	function resize() { canvas.width = canvas.clientWidth; canvas.height = canvas.clientHeight; }
 	resize();
@@ -66,17 +68,19 @@ export function initSpaceInvaders(canvas, onExit) {
 	window.addEventListener('keydown', keyHandler);
 	window.addEventListener('keyup', keyUpHandler);
 
-	function update() {
+	/** @param {number} deltaFrames */
+	function update(deltaFrames) {
 		if (gameState !== 'playing') return;
-		if (keys['ArrowLeft'] && playerX > 0) playerX -= PLAYER_SPEED;
-		if (keys['ArrowRight'] && playerX < canvas.width - PLAYER_W) playerX += PLAYER_SPEED;
-		if (shootCooldown > 0) shootCooldown--;
+		if (keys['ArrowLeft'] && playerX > 0) playerX -= PLAYER_SPEED * deltaFrames;
+		if (keys['ArrowRight'] && playerX < canvas.width - PLAYER_W) playerX += PLAYER_SPEED * deltaFrames;
+		playerX = Math.max(0, Math.min(canvas.width - PLAYER_W, playerX));
+		if (shootCooldown > 0) shootCooldown = Math.max(0, shootCooldown - deltaFrames);
 		if (keys[' '] && shootCooldown === 0) {
 			playerBullets.push({ x: playerX + PLAYER_W / 2 - BULLET_W / 2, y: playerY() - BULLET_H });
 			shootCooldown = 15;
 		}
 		for (let i = playerBullets.length - 1; i >= 0; i--) {
-			playerBullets[i].y -= BULLET_SPEED;
+			playerBullets[i].y -= BULLET_SPEED * deltaFrames;
 			if (playerBullets[i].y < 0) { playerBullets.splice(i, 1); continue; }
 			for (const alien of aliens) {
 				if (!alien.alive) continue;
@@ -90,7 +94,7 @@ export function initSpaceInvaders(canvas, onExit) {
 			}
 		}
 		if (aliens.every(a => !a.alive)) { gameState = 'won'; return; }
-		alienMoveTimer++;
+		alienMoveTimer += deltaFrames;
 		if (alienMoveTimer >= alienMoveInterval) {
 			alienMoveTimer = 0;
 			let shouldDrop = false;
@@ -103,10 +107,10 @@ export function initSpaceInvaders(canvas, onExit) {
 			for (const a of aliens) { if (a.alive && a.y + ALIEN_H >= playerY()) { gameState = 'gameover'; return; } }
 		}
 		for (const alien of aliens.filter(a => a.alive)) {
-			if (Math.random() < ALIEN_FIRE_CHANCE) alienBullets.push({ x: alien.x + ALIEN_W / 2 - BULLET_W / 2, y: alien.y + ALIEN_H });
+			if (Math.random() < ALIEN_FIRE_CHANCE * deltaFrames) alienBullets.push({ x: alien.x + ALIEN_W / 2 - BULLET_W / 2, y: alien.y + ALIEN_H });
 		}
 		for (let i = alienBullets.length - 1; i >= 0; i--) {
-			alienBullets[i].y += ALIEN_BULLET_SPEED;
+			alienBullets[i].y += ALIEN_BULLET_SPEED * deltaFrames;
 			if (alienBullets[i].y > canvas.height) { alienBullets.splice(i, 1); continue; }
 			if (alienBullets[i].x < playerX + PLAYER_W && alienBullets[i].x + BULLET_W > playerX && alienBullets[i].y < playerY() + PLAYER_H && alienBullets[i].y + BULLET_H > playerY()) {
 				alienBullets.splice(i, 1); lives--;
@@ -166,8 +170,17 @@ export function initSpaceInvaders(canvas, onExit) {
 		}
 	}
 
-	function gameLoop() { update(); draw(); animFrameId = requestAnimationFrame(gameLoop); }
-	resetAliens(); gameLoop();
+	/** @param {number} timestamp */
+	function gameLoop(timestamp) {
+		if (lastFrameTime === 0) lastFrameTime = timestamp;
+		const deltaFrames = Math.min((timestamp - lastFrameTime) / FRAME_MS, 3);
+		lastFrameTime = timestamp;
+
+		update(deltaFrames);
+		draw();
+		animFrameId = requestAnimationFrame(gameLoop);
+	}
+	resetAliens(); animFrameId = requestAnimationFrame(gameLoop);
 
 	return function cleanup() {
 		cancelAnimationFrame(animFrameId);

--- a/src/js/games/tetris.js
+++ b/src/js/games/tetris.js
@@ -23,6 +23,8 @@ export function initTetris(canvas, onExit) {
 	let score = 0, level = 1, lines = 0;
 	let highScore = parseInt(localStorage.getItem('tetrisHigh') || '0', 10);
 	let animFrameId = 0;
+	let lastFrameTime = 0;
+	const FRAME_MS = 1000 / 60;
 
 	/** @type {(string|null)[][]} */
 	let grid = [];
@@ -148,9 +150,10 @@ export function initTetris(canvas, onExit) {
 	window.addEventListener('keydown', keyHandler);
 	window.addEventListener('keyup', keyUpHandler);
 
-	function update() {
+	/** @param {number} deltaFrames */
+	function update(deltaFrames) {
 		if (gameState !== 'playing' || !currentPiece) return;
-		dropTimer++;
+		dropTimer += deltaFrames;
 		if (dropTimer >= dropInterval) {
 			dropTimer = 0;
 			if (!collides(currentPiece.shape, currentPiece.x, currentPiece.y + 1)) currentPiece.y++;
@@ -229,8 +232,17 @@ export function initTetris(canvas, onExit) {
 		}
 	}
 
-	function gameLoop() { update(); draw(); animFrameId = requestAnimationFrame(gameLoop); }
-	resetGrid(); gameLoop();
+	/** @param {number} timestamp */
+	function gameLoop(timestamp) {
+		if (lastFrameTime === 0) lastFrameTime = timestamp;
+		const deltaFrames = Math.min((timestamp - lastFrameTime) / FRAME_MS, 3);
+		lastFrameTime = timestamp;
+
+		update(deltaFrames);
+		draw();
+		animFrameId = requestAnimationFrame(gameLoop);
+	}
+	resetGrid(); animFrameId = requestAnimationFrame(gameLoop);
 
 	return function cleanup() {
 		cancelAnimationFrame(animFrameId);


### PR DESCRIPTION
## Summary
- Normalize game loops against a 60 FPS baseline using requestAnimationFrame timestamps
- Scale movement, gravity, timers, cooldowns, and random firing by elapsed frame time
- Clamp large frame gaps to avoid jumps after tab throttling

## Verification
- npm run build